### PR TITLE
Dev - I Added password hashing and relevant tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ User management API with role-based access control and compliance reporting.
 
 ### Further Development (I may develop these prior to Final Interview)
 
-- Fix further security issues (such as passwords being in plain text)
+- [RESOLVED] Fix further security issues (such as passwords being in plain text)
 - Demonstrate debugging practices and IDE integration
 - PostGres migration would be also ideal
 
@@ -176,7 +176,7 @@ GitHub Actions runs linting and tests on every push and pull request. See `.gith
 - `id` - Primary Key
 - `username` - Unique, Not Null
 - `email` - Unique, Not Null
-- `password` - Not Null (stored in plain text - known security issue)
+- `password` - Not Null (now hashed)
 - `inactive_since` - DateTime, Nullable (tracks when user was deactivated)
 - Many-to-Many relationship with `Role`
 

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -4,10 +4,11 @@ from ..extensions import db, bcrypt
 
 
 def create_user(username, email, password):
+    hashed_password = bcrypt.generate_password_hash(password).decode("utf-8")
     new_user = User(
         username=username,
         email=email,
-        password=password,
+        password=hashed_password,
         inactive_since=datetime.utcnow(),
     )
     db.session.add(new_user)
@@ -18,19 +19,13 @@ def create_user(username, email, password):
 def check_password(email, password):
     user = User.query.filter_by(email=email).first()
 
-    if user:
-        pass
-        # print(f"found user: {user.username}")
-        # print(f"email: {email}")
-        # print(f"password: {password}")
-        # print(f"db password: {user.password}")
-    else:
-        print("user not found")
-
-    if user.password == password:
-        return True
-    else:
+    if not user:
+        bcrypt.check_password_hash(
+            bcrypt.generate_password_hash("dummy").decode("utf-8"), password
+        )
         return False
+
+    return bcrypt.check_password_hash(user.password, password)
 
 
 def toggle_user_active(user_id):


### PR DESCRIPTION
### Implement Secure Password Hashing with bcrypt
Description
This is an extension into the 'bonus' section of the initial project's README covering the security issue of plain text passwords. This PR hashes passwords on creation with bcrypt

**Acceptance Criteria**

Hash all passwords using bcrypt before storage
Implement secure password verification
Add timing attack protection to prevent user enumeration
Ensure all existing tests pass with hashed passwords

This PR implements this functionality with the following:
Service Layer
Modified app/services/user_service.py:

create_user(): Hash password with bcrypt before storing
check_password(): Replaced plain text comparison with secure verification
Added timing attack protection for non-existent users

New Tests
Added to tests/test_auth.py covering:

Password hashing on registration (verifies $2b$ prefix)
Login with wrong password fails
bcrypt work factor validation

Testing
Run poetry run pytest --verbose and confirm:

All existing authentication tests pass
New password hashing tests pass
Passwords stored with $2b$12$ prefix (bcrypt format)
Login works with hashed passwords
Wrong passwords rejected with 401